### PR TITLE
Fix typo in "Find Kerberoastable users and where they are AdminTo" query

### DIFF
--- a/customqueries.json
+++ b/customqueries.json
@@ -1038,7 +1038,7 @@
                                 "category": "GPO/Group Information",
                                 "queryList": [{
                                     "final": true,
-                                    "query": "OPTIONAL MATCH (u1:User) WHERE u1.hasspn=true OPTIONAL MATCH (u1)-[r:AdminTo]->(c:Computer) RETURN u"
+                                    "query": "OPTIONAL MATCH (u1:User) WHERE u1.hasspn=true OPTIONAL MATCH (u1)-[r:AdminTo]->(c:Computer) RETURN u1"
                                 }]
                             },
                             {


### PR DESCRIPTION
Just a small typo in a query which returned an error