### PR TITLE
Query Fix

### DIFF
--- a/customqueries.json
+++ b/customqueries.json
@@ -696,7 +696,7 @@
                         "category": "Group Hunts",
                         "queryList": [{
                             "final": true,
-                            "query": "MATCH p=(g:Group)-[r:Owns|:WriteDacl|:GenericAll|:WriteOwner|:ExecuteDCOM|:GenericWrite|:AllowedToDelegate|:ForceChangePassword]->(n:Computer) WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
+                            "query": "MATCH p=(g:Group)-[r:Owns|WriteDacl|GenericAll|WriteOwner|ExecuteDCOM|GenericWrite|AllowedToDelegate|ForceChangePassword]->(n:Computer)  WHERE NOT g.name CONTAINS 'ADMIN' RETURN p",
                             "allowCollapse": true
                         }]
                     },


### PR DESCRIPTION
Fixed Error in Query where using a colon to separate alternative relationship types in conjunction with variable binding is no longer supported. - BH Version 4.3.1